### PR TITLE
Fix org name typo

### DIFF
--- a/_config.prod.yml
+++ b/_config.prod.yml
@@ -147,7 +147,7 @@ github:
   exokit_site:
     username: exokitxr
     repo: exokit-site
-    url: https://github.com/wemixedreality/exokit-site/
+    url: https://github.com/exokitxr/exokit-site/
 
 
 exokit_lib:


### PR DESCRIPTION
This PR fixes a 'wemixedreality' that never got caught because it had a typo.