### PR TITLE
Fix footer

### DIFF
--- a/themes/exokit/layout/partials/docs/footer.ejs
+++ b/themes/exokit/layout/partials/docs/footer.ejs
@@ -1,6 +1,6 @@
 <footer class="footer footnote">
   <p>
-    The Exokit project and content on this site are licensed under the <a href="https://github.com/exokitxr/exokit/blob/master/LICENSE" rel="external">MIT License</a>.
+    The Exokit Engine and content on this site are licensed under the <a href="https://github.com/exokitxr/exokit/blob/master/LICENSE.md" rel="external">MIT License</a>.
   </p>
   <p>Found a typo or suggestion for the docs? <br><br> <a href="<%- website_github_edit_url(item.path) %>" class="github-file-link" target="_blank" rel="external">Suggest an edit on GitHub</a></p>
 </footer>


### PR DESCRIPTION
This PR proposes to fix the `LICENSE.md` broken link in the footerand update to read as "Exokit Engine" specifically instead of "Exokit project".